### PR TITLE
#1 Adding LABEL to allow auto build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM alpine:3.2
 MAINTAINER Abiola Ibrahim <abiola89@gmail.com>
 
+LABEL caddy_version="0.8" architecture="amd64"
+
 RUN apk add --update openssh-client git tar
 
 RUN mkdir /caddysrc \


### PR DESCRIPTION
Currently, because the Caddy URL does not have a version number, this LABEL should help you trigger a build automatically. It will also allow someone in INSPECT see what version Caddy is.