### PR TITLE
Add plugins build arg to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,13 @@ MAINTAINER Abiola Ibrahim <abiola89@gmail.com>
 
 LABEL caddy_version="0.9.1" architecture="amd64"
 
+ARG plugins=git,ipfilter
+
 RUN apk add --update --no-cache openssh-client git tar curl
 
 RUN curl --silent --show-error --fail --location \
       --header "Accept: application/tar+gzip, application/x-gzip, application/octet-stream" -o - \
-      "https://caddyserver.com/download/build?os=linux&arch=amd64&features=git" \
+      "https://caddyserver.com/download/build?os=linux&arch=amd64&features=${plugins}" \
     | tar --no-same-owner -C /usr/bin/ -xz caddy \
  && chmod 0755 /usr/bin/caddy \
  && /usr/bin/caddy -version


### PR DESCRIPTION
This makes the installed plugins a build argument, so the list can be changed more easily, i.e. with:

```
docker build -t caddy --build-arg plugins=git,ipfilter,jwt .
```

It also adds the `ipfilter` plugin, but I could remove that if you prefer.