### PR TITLE
Add volume for caddy directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN curl --silent --show-error --fail --location \
  && /usr/bin/caddy -version
 
 EXPOSE 80 443 2015
+VOLUME /root/.caddy
 WORKDIR /srv
 
 COPY Caddyfile /etc/Caddyfile


### PR DESCRIPTION
The documentation mentions adding a volume to save certs to the host. I'm using docker-compose, and it makes a special effort to preserve volumes across recreations, as long as they are declared volumes in the docker file. Docker itself will also create temp dirs for this if the user does nothing else. 

This should be a minor convenience, but I'd like to have it if you don't mind.