### PR TITLE
Heighten amount of Warning around Lets Encrypt Limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,24 @@ $ docker run -d -p 2015:2015 abiosoft/caddy
 
 Point your browser to `http://127.0.0.1:2015`.
 
+> Be aware! If you don't bind mount the location certificates are saved to, you may bypass Lets Encrypt limits
+> rending further certificate generation disallowed! See "Saving Certificates" below!
+
+### Saving Certificates
+
+Save certificates on host machine to prevent regeneration every time container starts.
+Let's Encrypt has [rate limit](https://community.letsencrypt.org/t/rate-limits-for-lets-encrypt/6769).
+```sh
+$ docker run -d \
+    -v $(pwd)/Caddyfile:/etc/Caddyfile \
+    -v $HOME/.caddy:/root/.caddy \
+    -p 80:80 -p 443:443 \
+    abiosoft/caddy
+```
+
+
+Here, `/root/.caddy` is the location *inside* the container where caddy will save certificates.
+
 ### PHP
 `:[<version>-]php` variant of this image bundles PHP-FPM alongside essential php extensions and [composer](https://getcomposer.org). e.g. `:php`, `:0.8.0-php`
 ```sh
@@ -98,16 +116,6 @@ You can change the the ports if ports 80 and 443 are not available on host. e.g.
 ```sh
 $ docker run -d \
     -v $(pwd)/Caddyfile:/etc/Caddyfile \
-    -p 80:80 -p 443:443 \
-    abiosoft/caddy
-```
-
-**Optional** but advised. Save certificates on host machine to prevent regeneration every time container starts.
-Let's Encrypt has [rate limit](https://community.letsencrypt.org/t/rate-limits-for-lets-encrypt/6769).
-```sh
-$ docker run -d \
-    -v $(pwd)/Caddyfile:/etc/Caddyfile \
-    -v $HOME/.caddy:/root/.caddy \
     -p 80:80 -p 443:443 \
     abiosoft/caddy
 ```

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ $ docker run -d -p 2015:2015 abiosoft/caddy
 
 Point your browser to `http://127.0.0.1:2015`.
 
-> Be aware! If you don't bind mount the location certificates are saved to, you may bypass Lets Encrypt limits
-> rending further certificate generation disallowed! See "Saving Certificates" below!
+> Be aware! If you don't bind mount the location certificates are saved to, you may hit Let's Encrypt rate [limits](https://letsencrypt.org/docs/rate-limits/)
+> rending further certificate generation or renewal disallowed (for a fixed period)! See "Saving Certificates" below!
 
 ### Saving Certificates
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,20 @@ $ docker run -d \
 
 Here, `/root/.caddy` is the location *inside* the container where caddy will save certificates.
 
+Additionally, you can use an *environment variable* to define the exact location caddy should save generated certificates:
+
+```sh
+$ docker run -d \
+    -e "CADDYPATH=/etc/caddycerts" \
+    -v $HOME/.caddy:/etc/caddycerts \
+    -p 80:80 -p 443:443 \
+    abiosoft/caddy
+```
+
+Above, we utilize the `CADDYPATH` environment variable to define a different location inside the container for
+certificates to be stored. This is probably the safest option as it ensures any future docker image changes don't
+interfere with your ability to save certificates!
+
 ### PHP
 `:[<version>-]php` variant of this image bundles PHP-FPM alongside essential php extensions and [composer](https://getcomposer.org). e.g. `:php`, `:0.8.0-php`
 ```sh


### PR DESCRIPTION
I'm definitely not the first person to run into this and I definitely won't be the last.

Being in a situation in which you've expended all your certificate issuance for a variety of your application domains is extremely frustrating. This may be because you had to relaunch the container multiple times to test new feautures, breakage, or whatever else. When this happens, you either have to change the domain your application is accessed with (and CNAME) or go without SSL/TLS (unless you purchase a cert), which are both terrible options. 

This just bit me today because of the changes @abiosoft made around the tagged images for the last few versions. You can see below that the locations of certificates inside the containers has changed twice in the past 4 versions of caddy. 

* `0.9.0` - `/root/.caddy`
* `0.9.1` - `/home/caddy/.caddy`
* `0.9.2` - `/home/caddy/.caddy`
* `0.9.3` - `/root/.caddy`

Although, I don't understand why this was necessary, he does seem to keep the readme updated. However, this doesn't mean much if the information about which directory cert/keys are kept in is the last entry at the far bottom of the readme ;(

Additionally, I feel that on every tag, a github release should be cut with details about possible differences and things to watch out for. I know this isn't an "official" image but its popular enough (and used in semi-prod envs) to be dangerous if not fully understood.

This PR moves up the information about how to approach bind-mounting this directory and adds a quoted section reminding the user of what could happen. This needs to be at the forefront of every tag to ensure people upgrading in the future don't get bit by this.