### PR TITLE
Add php-xml

### DIFF
--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -8,7 +8,7 @@ ARG plugins=git
 RUN apk add --no-cache openssh-client git tar php5-fpm curl
 
 # essential php libs
-RUN apk add --no-cache php5-curl php5-gd php5-zip php5-iconv php5-sqlite3 php5-mysql php5-mysqli php5-pgsql php5-json php5-phar php5-openssl php5-pdo
+RUN apk add --no-cache php5-curl php5-gd php5-zip php5-xml php5-iconv php5-sqlite3 php5-mysql php5-mysqli php5-pgsql php5-json php5-phar php5-openssl php5-pdo
 
 # composer
 RUN curl --silent --show-error --fail --location \


### PR DESCRIPTION
I would like php5-xml to be included because

1. WordPress needs it for XMLRPC, and
2. SimpleXML and various XML related extensions are already installed - only for it to break because there's no XML parser.

Please review this, thanks!