### PR TITLE
Add php7-mbstring extension

### DIFF
--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -8,7 +8,7 @@ ARG plugins=git
 RUN apk add --no-cache openssh-client git tar php7-fpm curl
 
 # essential php libs
-RUN apk add --no-cache php7-curl php7-dom php7-gd php7-ctype php7-zip php7-xml php7-iconv php7-sqlite3 php7-mysqli php7-pgsql php7-json php7-phar php7-openssl php7-pdo php7-pdo_mysql php7-session
+RUN apk add --no-cache php7-curl php7-dom php7-gd php7-ctype php7-zip php7-xml php7-iconv php7-sqlite3 php7-mysqli php7-pgsql php7-json php7-phar php7-openssl php7-pdo php7-pdo_mysql php7-session php7-mbstring
 
 # symblink php7 to php
 RUN ln -sf /usr/bin/php7 /usr/bin/php 


### PR DESCRIPTION
This was available with php5 and upgrading to php7 broke compatibility for this docker image