### PR TITLE
Pull `caddy_version` label from version build arg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,8 @@ RUN VERSION=${version} PLUGINS=${plugins} /bin/sh /usr/bin/builder.sh
 FROM alpine:3.7
 LABEL maintainer "Abiola Ibrahim <abiola89@gmail.com>"
 
-LABEL caddy_version="0.10.11"
+ARG version="0.10.11"
+LABEL caddy_version="$version"
 
 RUN apk add --no-cache openssh-client git
 


### PR DESCRIPTION
Fixes mismatch between the version built in the first stage of the build
and the `caddy_version` label.

E.g., building with `--build-arg=version=0.10.10` resulted in an image
containing `Caddy 0.10.10 (unofficial)`, but labeled as
`caddy_version=0.10.11`:

    $ repo=https://github.com/abiosoft/caddy-docker.git
    $ docker build --build-arg=version=0.10.10 -t custom-caddy ${repo?}
    ...
    Successfully built 6cdd710bec4c
    Successfully tagged custom-caddy:latest

    $ docker run --rm custom-caddy --version
    Caddy 0.10.10 (unofficial)

    $ format=caddy_version={{.ContainerConfig.Labels.caddy_version}}
    $ docker inspect --format=$format custom-caddy 6cdd710bec4c
    caddy_version=0.10.11
    caddy_version=0.10.11