### PR TITLE
Fix `caddy_version` label in `php/Dockerfile`

### DIFF
--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -14,7 +14,8 @@ RUN VERSION=${version} PLUGINS=${plugins} /bin/sh /usr/bin/builder.sh
 FROM alpine:3.7
 LABEL maintainer "Abiola Ibrahim <abiola89@gmail.com>"
 
-LABEL caddy_version="0.10.11"
+ARG version="0.10.11"
+LABEL caddy_version="$version"
 
 RUN apk add --no-cache openssh-client git tar php7-fpm curl
 


### PR DESCRIPTION
`caddy_version` label wasn't pulled from the `version` build arg, so the
label was mismatched when using a value other than the default.