### PR TITLE
Make Caddyfile can be in a volume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,9 +30,9 @@ EXPOSE 80 443 2015
 VOLUME /root/.caddy /srv
 WORKDIR /srv
 
-COPY Caddyfile /etc/Caddyfile
+COPY Caddyfile /etc/caddy/Caddyfile
 COPY index.html /srv/index.html
 
 ENTRYPOINT ["/usr/bin/caddy"]
-CMD ["--conf", "/etc/Caddyfile", "--log", "stdout"]
+CMD ["--conf", "/etc/caddy/Caddyfile", "--log", "stdout"]
 


### PR DESCRIPTION
If the Caddyfile in /etc, when I mount a volume overwrite /etc, all /etc will lose, but if it's in the /etc/caddy dir, I can mount a volume to it and It's work perfect.