### PR TITLE
Use alpine 3:8 for PHP images

### DIFF
--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -14,7 +14,7 @@ RUN VERSION=${version} PLUGINS=${plugins} /bin/sh /usr/bin/builder.sh
 #
 # Final stage
 #
-FROM alpine:3.7
+FROM alpine:3.8
 LABEL maintainer "Abiola Ibrahim <abiola89@gmail.com>"
 
 ARG version="0.11.0"

--- a/php/Dockerfile-no-stats
+++ b/php/Dockerfile-no-stats
@@ -14,7 +14,7 @@ RUN VERSION=${version} PLUGINS=${plugins} ENABLE_TELEMETRY=false /bin/sh /usr/bi
 #
 # Final stage
 #
-FROM alpine:3.7
+FROM alpine:3.8
 LABEL maintainer "Abiola Ibrahim <abiola89@gmail.com>"
 
 ARG version="0.11.0"


### PR DESCRIPTION
This PR updates the PHP images to use`alpine:3.8` instead of `alpine:3.7` do gain access to PHP 7.2.

Closes #129 