### PR TITLE
Use alpine 3:8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN VERSION=${version} PLUGINS=${plugins} /bin/sh /usr/bin/builder.sh
 #
 # Final stage
 #
-FROM alpine:3.7
+FROM alpine:3.8
 LABEL maintainer "Abiola Ibrahim <abiola89@gmail.com>"
 
 ARG version="0.11.0"

--- a/Dockerfile-no-stats
+++ b/Dockerfile-no-stats
@@ -14,7 +14,7 @@ RUN VERSION=${version} PLUGINS=${plugins} ENABLE_TELEMETRY=false /bin/sh /usr/bi
 #
 # Final stage
 #
-FROM alpine:3.7
+FROM alpine:3.8
 LABEL maintainer "Abiola Ibrahim <abiola89@gmail.com>"
 
 ARG version="0.11.0"


### PR DESCRIPTION
Use `alpine:3.8` instead of `alpine:3.7`. Related to #130 but not 100% sure if necessary for non-PHP images.