### PR TITLE
Temporary workaround for caddy plugin error

### DIFF
--- a/builder/builder.sh
+++ b/builder/builder.sh
@@ -3,6 +3,11 @@
 VERSION=${VERSION:-"0.11.0"}
 TELEMETRY=${ENABLE_TELEMETRY:-"true"}
 
+# workaround for https://github.com/abiosoft/caddy-docker/issues/151
+git clone https://github.com/xenolf/lego /go/src/github.com/xenolf/lego \
+    && cd /go/src/github.com/xenolf/lego \
+    && git checkout "4e842a5eb6dcb9520e03db70cd5896f1df14b72a"
+
 # caddy
 git clone https://github.com/mholt/caddy -b "v$VERSION" /go/src/github.com/mholt/caddy \
     && cd /go/src/github.com/mholt/caddy \


### PR DESCRIPTION
This is clearly not the ideal fix for #151, but I figured it was worth pushing to a PR because the right fix looks like it might require quite a bit of improvement to caddy plugins to handle dependency versioning (as well as related changes to caddyplug and builder) and it would be nice for builder to still be functional in the mean time.