### PR TITLE
Add XMLReader and XMLWriter php modules

### DIFF
--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -26,7 +26,7 @@ ENV ACME_AGREE="false"
 RUN apk add --no-cache openssh-client git tar php7-fpm curl
 
 # essential php libs
-RUN apk add --no-cache php7-curl php7-dom php7-gd php7-ctype php7-zip php7-xml php7-iconv php7-sqlite3 php7-mysqli php7-pgsql php7-json php7-phar php7-openssl php7-pdo php7-pdo_mysql php7-session php7-mbstring php7-bcmath php7-tokenizer php7-fileinfo
+RUN apk add --no-cache php7-curl php7-dom php7-gd php7-ctype php7-zip php7-xml php7-xmlreader php7-xmlwriter php7-iconv php7-sqlite3 php7-mysqli php7-pgsql php7-json php7-phar php7-openssl php7-pdo php7-pdo_mysql php7-session php7-mbstring php7-bcmath php7-tokenizer php7-fileinfo
 
 # symblink php7 to php
 RUN ln -sf /usr/bin/php7 /usr/bin/php

--- a/php/Dockerfile-no-stats
+++ b/php/Dockerfile-no-stats
@@ -29,7 +29,7 @@ ENV ENABLE_TELEMETRY="false"
 RUN apk add --no-cache openssh-client git tar php7-fpm curl
 
 # essential php libs
-RUN apk add --no-cache php7-curl php7-dom php7-gd php7-ctype php7-zip php7-xml php7-iconv php7-sqlite3 php7-mysqli php7-pgsql php7-json php7-phar php7-openssl php7-pdo php7-pdo_mysql php7-session php7-mbstring php7-bcmath php7-tokenizer php7-fileinfo
+RUN apk add --no-cache php7-curl php7-dom php7-gd php7-ctype php7-zip php7-xml php7-xmlreader php7-xmlwriter php7-iconv php7-sqlite3 php7-mysqli php7-pgsql php7-json php7-phar php7-openssl php7-pdo php7-pdo_mysql php7-session php7-mbstring php7-bcmath php7-tokenizer php7-fileinfo
 
 # symblink php7 to php
 RUN ln -sf /usr/bin/php7 /usr/bin/php


### PR DESCRIPTION
It seems that lots of modern php applications require XMLReader (ex: WordPress) and XMLWriter php modules installed to work correctly