### PR TITLE
Update go version from 1.11.0 to 1.11.5

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11.0-alpine
+FROM golang:1.11.5-alpine
 
 RUN apk add --no-cache git gcc musl-dev
 


### PR DESCRIPTION
Update go version in order to include security fix on "go get" and "crypto/x509" package.