### PR TITLE
Add BuildKit definition file for cross-platform registry image

### DIFF
--- a/BUILDER.md
+++ b/BUILDER.md
@@ -18,7 +18,7 @@ docker run --rm -v $(pwd):/install -e PLUGINS=git,filebrowser abiosoft/caddy:bui
 ### Environment Variables
 
 - `PLUGINS` - comma separated Caddy plugins. e.g. `-e PLUGINS=git,linode`
-- `VERSION` - Caddy version or repository branch. Default `1.0.3`
+- `VERSION` - Caddy version or repository branch. Default `2.0.0`
 - `ENABLE_TELEMETRY` - Enable telemetry stats. Options `true`|`false`. Default `true`
 - `GOOS`, `GOARCH` and `GOARM` are all supported, but buildkit is the new way
   to specify architecture

--- a/BUILDER.md
+++ b/BUILDER.md
@@ -20,4 +20,5 @@ docker run --rm -v $(pwd):/install -e PLUGINS=git,filebrowser abiosoft/caddy:bui
 - `PLUGINS` - comma separated Caddy plugins. e.g. `-e PLUGINS=git,linode`
 - `VERSION` - Caddy version or repository branch. Default `1.0.3`
 - `ENABLE_TELEMETRY` - Enable telemetry stats. Options `true`|`false`. Default `true`
-- `GOOS`, `GOARCH` and `GOARM` are all supported. Default `GOOS=linux`, `GOARCH=amd64`
+- `GOOS`, `GOARCH` and `GOARM` are all supported, but buildkit is the new way
+  to specify architecture

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #
 # Builder
 #
-FROM abiosoft/caddy:builder as builder
+FROM paullj1/caddy-arm:builder as builder
 
 ARG version="0.11.5"
 ARG plugins="git,filebrowser,cors,realip,expires,cache"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 #
 # Builder
 #
-FROM abiosoft/caddy:builder as builder
+FROM paullj1/caddy:builder as builder
 
-ARG version="1.0.3"
+ARG version="2.0.0"
 ARG plugins="git,cors,realip,expires,cache,cloudflare"
 ARG enable_telemetry="true"
 
@@ -15,10 +15,10 @@ RUN VERSION=${version} PLUGINS=${plugins} ENABLE_TELEMETRY=${enable_telemetry} /
 #
 # Final stage
 #
-FROM alpine:3.10
+FROM alpine:3.11
 LABEL maintainer "Abiola Ibrahim <abiola89@gmail.com>"
 
-ARG version="1.0.3"
+ARG version="2.0.0"
 LABEL caddy_version="$version"
 
 # Let's Encrypt Agreement

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #
 # Builder
 #
-FROM paullj1/caddy-arm:builder as builder
+FROM abiosoft/caddy:builder as builder
 
 ARG version="1.0.3"
 ARG plugins="git,cors,realip,expires,cache,cloudflare"

--- a/Dockerfile-no-stats
+++ b/Dockerfile-no-stats
@@ -3,7 +3,7 @@
 #
 FROM abiosoft/caddy:builder as builder
 
-ARG version="1.0.3"
+ARG version="2.0.0"
 ARG plugins="git,cors,realip,expires,cache,cloudflare"
 
 # process wrapper
@@ -14,10 +14,10 @@ RUN VERSION=${version} PLUGINS=${plugins} ENABLE_TELEMETRY=false /bin/sh /usr/bi
 #
 # Final stage
 #
-FROM alpine:3.10
+FROM alpine:3.11
 LABEL maintainer "Abiola Ibrahim <abiola89@gmail.com>"
 
-ARG version="1.0.3"
+ARG version="2.0.0"
 LABEL caddy_version="$version"
 
 # Let's Encrypt Agreement

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A [Docker](https://docker.com) image for [Caddy](https://caddyserver.com). This 
 Plugins can be configured via the [`plugins` build arg](#custom-plugins).
 
 [![](https://images.microbadger.com/badges/image/abiosoft/caddy.svg)](https://microbadger.com/images/abiosoft/caddy "Get your own image badge on microbadger.com")
-[![](https://img.shields.io/badge/version-1.0.3-blue.svg)](https://github.com/caddyserver/caddy/tree/v1.0.3)
+[![](https://img.shields.io/badge/version-2.0.0-blue.svg)](https://github.com/caddyserver/caddy/tree/v2.0.0)
 
 Check [abiosoft/caddy:builder](https://github.com/abiosoft/caddy-docker/blob/master/BUILDER.md) for generating cross-platform Caddy binaries.
 

--- a/builder/builder.sh
+++ b/builder/builder.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-VERSION=${VERSION:-"1.0.3"}
+VERSION=${VERSION:-"2.0.0"}
 TELEMETRY=${ENABLE_TELEMETRY:-"true"}
 IMPORT="github.com/caddyserver/caddy"
 

--- a/builder/builder.sh
+++ b/builder/builder.sh
@@ -131,7 +131,7 @@ end_stage
 
 # plugin helper
 stage "installing plugin helper"
-GOOS=linux GOARCH=amd64 go get -v github.com/abiosoft/caddyplug/caddyplug
+GOOS=linux go get -v github.com/abiosoft/caddyplug/caddyplug
 end_stage
 
 # check for modules support

--- a/builder/builder.sh
+++ b/builder/builder.sh
@@ -9,8 +9,8 @@ git clone https://github.com/mholt/caddy -b "v$VERSION" /go/src/github.com/mholt
     && git checkout -b "v$VERSION"
 
 # plugin helper
-GOOS=linux GOARCH=amd64 go get -v github.com/abiosoft/caddyplug/caddyplug
-alias caddyplug='GOOS=linux GOARCH=amd64 caddyplug'
+GOOS=linux GOARCH=arm GOARM=5 go get -v github.com/abiosoft/caddyplug/caddyplug
+alias caddyplug='GOOS=linux GOARCH=arm GOARM=5 caddyplug'
 
 # telemetry
 run_file="/go/src/github.com/mholt/caddy/caddy/caddymain/run.go"
@@ -41,7 +41,7 @@ git clone https://github.com/caddyserver/builds /go/src/github.com/caddyserver/b
 
 # build
 cd /go/src/github.com/mholt/caddy/caddy \
-    && GOOS=linux GOARCH=amd64 go run build.go -goos=$GOOS -goarch=$GOARCH -goarm=$GOARM \
+    && GOOS=linux GOARCH=arm GOARM=5 go run build.go -goos=$GOOS -goarch=$GOARCH -goarm=$GOARM \
     && mkdir -p /install \
     && mv caddy /install
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -8,8 +8,8 @@ target "caddy" {
   dockerfile = "Dockerfile"
   output = ["type=registry"]
   driver = "docker-container"
-  tags = ["docker.io/abiosoft/caddy-docker:latest",
-          "docker.io/abiosoft/caddy-docker:1.0.3" ]
+  tags = ["docker.io/abiosoft/caddy:latest",
+          "docker.io/abiosoft/caddy:1.0.3" ]
   platforms = ["linux/amd64", "linux/arm64", "linux/arm/v6", "linux/arm/v7"]
 }
 
@@ -18,7 +18,7 @@ target "builder" {
   dockerfile = "Dockerfile"
   output = ["type=registry"]
   driver = "docker-container"
-  tags = ["docker.io/abiosoft/caddy-docker:latest"]
+  tags = ["docker.io/abiosoft/caddy:builder"]
   platforms = ["linux/amd64", "linux/arm64", "linux/arm/v6", "linux/arm/v7"]
 }
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -8,9 +8,9 @@ target "caddy" {
   dockerfile = "Dockerfile"
   output = ["type=registry"]
   driver = "docker-container"
-  tags = ["docker.io/abiosoft/caddy:latest",
-          "docker.io/abiosoft/caddy:1.0.3" ]
-  platforms = ["linux/amd64", "linux/arm64", "linux/arm/v6", "linux/arm/v7"]
+  tags = ["docker.io/paullj1/caddy:latest",
+          "docker.io/paullj1/caddy:2.0.0" ]
+  platforms = ["linux/amd64", "linux/arm64", "linux/arm/v7"]
 }
 
 target "builder" {
@@ -18,7 +18,7 @@ target "builder" {
   dockerfile = "Dockerfile"
   output = ["type=registry"]
   driver = "docker-container"
-  tags = ["docker.io/abiosoft/caddy:builder"]
-  platforms = ["linux/amd64", "linux/arm64", "linux/arm/v6", "linux/arm/v7"]
+  tags = ["docker.io/paullj1/caddy:builder"]
+  platforms = ["linux/amd64", "linux/arm64", "linux/arm/v7"]
 }
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -9,7 +9,7 @@ target "caddy" {
   output = ["type=registry"]
   driver = "docker-container"
   tags = ["docker.io/abiosoft/caddy-docker:latest",
-          "docker.io/abiosoft/caddy-docker:" ]
+          "docker.io/abiosoft/caddy-docker:1.0.3" ]
   platforms = ["linux/amd64", "linux/arm64", "linux/arm/v6", "linux/arm/v7"]
 }
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,0 +1,24 @@
+
+group "default" {
+  targets = ["caddy", "builder"]
+}
+
+target "caddy" {
+  context = "./"
+  dockerfile = "Dockerfile"
+  output = ["type=registry"]
+  driver = "docker-container"
+  tags = ["docker.io/abiosoft/caddy-docker:latest",
+          "docker.io/abiosoft/caddy-docker:" ]
+  platforms = ["linux/amd64", "linux/arm64", "linux/arm/v6", "linux/arm/v7"]
+}
+
+target "builder" {
+  context = "./builder/"
+  dockerfile = "Dockerfile"
+  output = ["type=registry"]
+  driver = "docker-container"
+  tags = ["docker.io/abiosoft/caddy-docker:latest"]
+  platforms = ["linux/amd64", "linux/arm64", "linux/arm/v6", "linux/arm/v7"]
+}
+

--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -3,7 +3,7 @@
 #
 FROM abiosoft/caddy:builder as builder
 
-ARG version="1.0.3"
+ARG version="2.0.0"
 ARG plugins="git,cors,realip,expires,cache,cloudflare"
 ARG enable_telemetry="true"
 
@@ -15,10 +15,10 @@ RUN VERSION=${version} PLUGINS=${plugins} ENABLE_TELEMETRY=${enable_telemetry} /
 #
 # Final Stage
 #
-FROM alpine:3.10
+FROM alpine:3.11
 LABEL maintainer "Abiola Ibrahim <abiola89@gmail.com>"
 
-ARG version="1.0.3"
+ARG version="2.0.0"
 LABEL caddy_version="$version"
 
 # PHP www-user UID and GID

--- a/php/Dockerfile-no-stats
+++ b/php/Dockerfile-no-stats
@@ -3,7 +3,7 @@
 #
 FROM abiosoft/caddy:builder as builder
 
-ARG version="1.0.3"
+ARG version="2.0.0"
 ARG plugins="git,cors,realip,expires,cache,cloudflare"
 
 # Process Wrapper
@@ -14,10 +14,10 @@ RUN VERSION=${version} PLUGINS=${plugins} ENABLE_TELEMETRY=false /bin/sh /usr/bi
 #
 # Final Stage
 #
-FROM alpine:3.10
+FROM alpine:3.11
 LABEL maintainer "Abiola Ibrahim <abiola89@gmail.com>"
 
-ARG version="1.0.3"
+ARG version="2.0.0"
 LABEL caddy_version="$version"
 
 # PHP www-user UID and GID


### PR DESCRIPTION
Just run:
```
docker builds bake -f docker-bake.hcl builder
docker builds bake -f docker-bake.hcl caddy
```
Buildkit will then build and push a multi-image registry manifest so it won't matter which architecture the client is using, they'll get the correct image (ARMv6, ARMv7, ARM64, or amd64).