### PR TITLE
update to 1.0.4

### DIFF
--- a/BUILDER.md
+++ b/BUILDER.md
@@ -18,6 +18,6 @@ docker run --rm -v $(pwd):/install -e PLUGINS=git,filebrowser abiosoft/caddy:bui
 ### Environment Variables
 
 - `PLUGINS` - comma separated Caddy plugins. e.g. `-e PLUGINS=git,linode`
-- `VERSION` - Caddy version or repository branch. Default `1.0.3`
+- `VERSION` - Caddy version or repository branch. Default `1.0.4`
 - `ENABLE_TELEMETRY` - Enable telemetry stats. Options `true`|`false`. Default `true`
 - `GOOS`, `GOARCH` and `GOARM` are all supported. Default `GOOS=linux`, `GOARCH=amd64`

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 #
 FROM abiosoft/caddy:builder as builder
 
-ARG version="1.0.3"
+ARG version="1.0.4"
 ARG plugins="git,cors,realip,expires,cache,cloudflare"
 ARG enable_telemetry="true"
 
@@ -18,7 +18,7 @@ RUN VERSION=${version} PLUGINS=${plugins} ENABLE_TELEMETRY=${enable_telemetry} /
 FROM alpine:3.10
 LABEL maintainer "Abiola Ibrahim <abiola89@gmail.com>"
 
-ARG version="1.0.3"
+ARG version="1.0.4"
 LABEL caddy_version="$version"
 
 # Let's Encrypt Agreement

--- a/Dockerfile-no-stats
+++ b/Dockerfile-no-stats
@@ -3,7 +3,7 @@
 #
 FROM abiosoft/caddy:builder as builder
 
-ARG version="1.0.3"
+ARG version="1.0.4"
 ARG plugins="git,cors,realip,expires,cache,cloudflare"
 
 # process wrapper
@@ -17,7 +17,7 @@ RUN VERSION=${version} PLUGINS=${plugins} ENABLE_TELEMETRY=false /bin/sh /usr/bi
 FROM alpine:3.10
 LABEL maintainer "Abiola Ibrahim <abiola89@gmail.com>"
 
-ARG version="1.0.3"
+ARG version="1.0.4"
 LABEL caddy_version="$version"
 
 # Let's Encrypt Agreement

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A [Docker](https://docker.com) image for [Caddy](https://caddyserver.com). This 
 Plugins can be configured via the [`plugins` build arg](#custom-plugins).
 
 [![](https://images.microbadger.com/badges/image/abiosoft/caddy.svg)](https://microbadger.com/images/abiosoft/caddy "Get your own image badge on microbadger.com")
-[![](https://img.shields.io/badge/version-1.0.3-blue.svg)](https://github.com/caddyserver/caddy/tree/v1.0.3)
+[![](https://img.shields.io/badge/version-1.0.4-blue.svg)](https://github.com/caddyserver/caddy/tree/v1.0.4)
 
 Check [abiosoft/caddy:builder](https://github.com/abiosoft/caddy-docker/blob/master/BUILDER.md) for generating cross-platform Caddy binaries.
 

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12-alpine
+FROM golang:1.13-alpine
 
 RUN apk add --no-cache git gcc musl-dev
 

--- a/builder/builder.sh
+++ b/builder/builder.sh
@@ -42,7 +42,7 @@ get_package() {
         cp -r /dnsproviders/$1/$1.go /caddy/dnsproviders/$1/$1.go
         echo "caddy/dnsproviders/$1"
     else
-        GO111MODULE=off GOOS=linux GOARCH=amd64 caddyplug package $1 2> /dev/null
+        GO111MODULE=off caddyplug package $1 2> /dev/null
     fi
 }
 
@@ -131,7 +131,7 @@ end_stage
 
 # plugin helper
 stage "installing plugin helper"
-GOOS=linux GOARCH=amd64 go get -v github.com/abiosoft/caddyplug/caddyplug
+go get -v github.com/abiosoft/caddyplug/caddyplug
 end_stage
 
 # check for modules support
@@ -155,7 +155,7 @@ end_stage
 
 # build
 stage "building caddy"
-CGO_ENABLED=0 go build -o caddy
+CGO_ENABLED=0 go build -ldflags '-w -s -extldflags "-static"' -o caddy
 end_stage
 
 # copy binary

--- a/builder/builder.sh
+++ b/builder/builder.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-VERSION=${VERSION:-"1.0.3"}
+VERSION=${VERSION:-"1.0.4"}
 TELEMETRY=${ENABLE_TELEMETRY:-"true"}
 IMPORT="github.com/caddyserver/caddy"
 

--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -3,7 +3,7 @@
 #
 FROM abiosoft/caddy:builder as builder
 
-ARG version="1.0.3"
+ARG version="1.0.4"
 ARG plugins="git,cors,realip,expires,cache,cloudflare"
 ARG enable_telemetry="true"
 
@@ -18,7 +18,7 @@ RUN VERSION=${version} PLUGINS=${plugins} ENABLE_TELEMETRY=${enable_telemetry} /
 FROM alpine:3.10
 LABEL maintainer "Abiola Ibrahim <abiola89@gmail.com>"
 
-ARG version="1.0.3"
+ARG version="1.0.4"
 LABEL caddy_version="$version"
 
 # PHP www-user UID and GID

--- a/php/Dockerfile-no-stats
+++ b/php/Dockerfile-no-stats
@@ -3,7 +3,7 @@
 #
 FROM abiosoft/caddy:builder as builder
 
-ARG version="1.0.3"
+ARG version="1.0.4"
 ARG plugins="git,cors,realip,expires,cache,cloudflare"
 
 # Process Wrapper
@@ -17,7 +17,7 @@ RUN VERSION=${version} PLUGINS=${plugins} ENABLE_TELEMETRY=false /bin/sh /usr/bi
 FROM alpine:3.10
 LABEL maintainer "Abiola Ibrahim <abiola89@gmail.com>"
 
-ARG version="1.0.3"
+ARG version="1.0.4"
 LABEL caddy_version="$version"
 
 # PHP www-user UID and GID


### PR DESCRIPTION
* Updated Caddy to 1.0.4
* Updated Go Docker Image to 1.13

This also closes Issue #225, maybe #228 and PR #224

[Changelog](https://github.com/caddyserver/caddy/releases/tag/v1.0.4) from Caddy
> This patch release fixes a bug in the fastcgi middleware that could result in the static file server returning PHP files as plain text on Windows systems. [...]
> Dependencies lego, certmagic, and quic-go have also been updated to their latest versions.